### PR TITLE
Implement PodController

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,17 +7,19 @@ import (
 	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/ruicao93/antrea-operator/pkg/controller/sharedinfo"
 	operatorversion "github.com/ruicao93/antrea-operator/pkg/version"
 )
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager
-var AddToManagerFuncs []func(manager.Manager, *statusmanager.StatusManager) error
+var AddToManagerFuncs []func(manager.Manager, *statusmanager.StatusManager, *sharedinfo.SharedInfo) error
 
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager) error {
 	s := statusmanager.New(m.GetClient(), m.GetRESTMapper(), "antrea", operatorversion.Version)
+	sharedInfo := sharedinfo.New()
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, s); err != nil {
+		if err := f(m, s, sharedInfo); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/sharedinfo/sharedinfo.go
+++ b/pkg/controller/sharedinfo/sharedinfo.go
@@ -1,0 +1,17 @@
+package sharedinfo
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type SharedInfo struct {
+	sync.Mutex
+	AntreaAgentDaemonSetSpec       *unstructured.Unstructured
+	AntreaControllerDeploymentSpec *unstructured.Unstructured
+}
+
+func New() *SharedInfo {
+	return &SharedInfo{}
+}


### PR DESCRIPTION
Implement PodController:
- Update cluster operator status when Antrea Pods status change.
- Recreate antrea-agent Daemonset or antrea-controller Deployment
  when the resource get deleted.

Signed-off-by: Rui Cao <rcao@vmware.com>