### PR TITLE
Add tolerations for operator deployment (#11)

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,6 +14,11 @@ spec:
         name: antrea-operator
     spec:
       hostNetwork: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
       serviceAccountName: antrea-operator
       containers:
         - name: antrea-operator


### PR DESCRIPTION
Operator should can run on master or not-ready nodes.

Signed-off-by: Rui Cao <rcao@vmware.com>