### PR TITLE
Update antreainstall.status from antrea clusteroperator.status

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -98,6 +98,9 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Setup release version
+	os.Setenv("RELEASE_VERSION", version.Version)
+
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
 		log.Error(err, "")

--- a/manifest/antrea.yml
+++ b/manifest/antrea.yml
@@ -706,6 +706,8 @@ metadata:
     component: antrea-controller
   name: antrea-controller
   namespace: kube-system
+  annotations:
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   replicas: 1
   selector:
@@ -834,6 +836,8 @@ metadata:
     component: antrea-agent
   name: antrea-agent
   namespace: kube-system
+  annotations:
+    release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
     matchLabels:

--- a/pkg/controller/add_status.go
+++ b/pkg/controller/add_status.go
@@ -1,0 +1,11 @@
+/* Copyright © 2020 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package controller
+
+import "github.com/ruicao93/antrea-operator/pkg/controller/status"
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, status.Add)
+}

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -14,6 +14,7 @@ import (
 
 	operatorv1 "github.com/ruicao93/antrea-operator/pkg/apis/operator/v1"
 	"github.com/ruicao93/antrea-operator/pkg/types"
+	"github.com/ruicao93/antrea-operator/version"
 )
 
 func FillConfigs(clusterConfig *configv1.Network, operConfig *operatorv1.AntreaInstall) error {
@@ -223,6 +224,7 @@ func pluginCNIConfDir(conf *ocoperv1.NetworkSpec) string {
 func GenerateRenderData(operatorNetwork *ocoperv1.Network, operConfig *operatorv1.AntreaInstall) (*render.RenderData, error) {
 	renderData := render.MakeRenderData()
 
+	renderData.Data[types.ReleaseVersion] = version.Version
 	renderData.Data[types.AntreaAgentConfigRenderKey] = operConfig.Spec.AntreaAgentConfig
 	renderData.Data[types.AntreaCNIConfigRenderKey] = operConfig.Spec.AntreaCNIConfig
 	renderData.Data[types.AntreaControllerConfigRenderKey] = operConfig.Spec.AntreaControllerConfig

--- a/pkg/controller/config/config_test.go
+++ b/pkg/controller/config/config_test.go
@@ -18,6 +18,7 @@ import (
 
 	operatorv1 "github.com/ruicao93/antrea-operator/pkg/apis/operator/v1"
 	operatortypes "github.com/ruicao93/antrea-operator/pkg/types"
+	"github.com/ruicao93/antrea-operator/version"
 )
 
 var mockClusterConfig = configv1.Network{
@@ -134,6 +135,12 @@ func TestRender(t *testing.T) {
 			err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), antreaDeployment)
 			g.Expect(err).ShouldNot(HaveOccurred())
 			g.Expect(antreaDeployment.Spec.Template.Spec.Containers[0].Image).Should(Equal(operatortypes.DefaultAntreaImage))
+			g.Expect(antreaDeployment.Annotations["release.openshift.io/version"]).Should(Equal(version.Version))
+		} else if obj.GetKind() == "DaemonSet" && obj.GetNamespace() == "kube-system" && obj.GetName() == "antrea-agent" {
+			antreaDaemonSet := &appsv1.DaemonSet{}
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), antreaDaemonSet)
+			g.Expect(err).ShouldNot(HaveOccurred())
+			g.Expect(antreaDaemonSet.Annotations["release.openshift.io/version"]).Should(Equal(version.Version))
 		}
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -8,6 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/ruicao93/antrea-operator/pkg/controller/sharedinfo"
+	"github.com/ruicao93/antrea-operator/pkg/types"
 	"github.com/ruicao93/antrea-operator/version"
 )
 
@@ -16,7 +17,7 @@ var AddToManagerFuncs []func(manager.Manager, *statusmanager.StatusManager, *sha
 
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager) error {
-	s := statusmanager.New(m.GetClient(), m.GetRESTMapper(), "antrea", version.Version)
+	s := statusmanager.New(m.GetClient(), m.GetRESTMapper(), types.AntreaClusterOperatorName, version.Version)
 	sharedInfo := sharedinfo.New()
 	for _, f := range AddToManagerFuncs {
 		if err := f(m, s, sharedInfo); err != nil {

--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -28,7 +28,7 @@ import (
 var log = logf.Log.WithName("controller_pod")
 
 // The periodic resync interval.
-// We will re-run the reconciliation logic, even if the NCP configuration
+// We will re-run the reconciliation logic, even if the configuration
 // hasn't changed.
 var ResyncPeriod = 2 * time.Minute
 
@@ -80,11 +80,11 @@ type ReconcilePod struct {
 // Reconcile updates the ClusterOperator.Status to match the current state of the watched Deployments/DaemonSets
 func (r *ReconcilePod) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling pod update")
 
 	if !r.isAntreaResource(&request) {
 		return reconcile.Result{}, nil
 	}
+	reqLogger.Info("Reconciling pod update")
 	r.status.SetFromPods()
 
 	if err := r.recreateResourceIfNotExist(&request); err != nil {

--- a/pkg/controller/status/status_controller.go
+++ b/pkg/controller/status/status_controller.go
@@ -1,0 +1,112 @@
+/* Copyright © 2020 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package status
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cluster-network-operator/pkg/controller/statusmanager"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	operatorv1 "github.com/ruicao93/antrea-operator/pkg/apis/operator/v1"
+	"github.com/ruicao93/antrea-operator/pkg/controller/sharedinfo"
+	operatortypes "github.com/ruicao93/antrea-operator/pkg/types"
+)
+
+var log = logf.Log.WithName("controller_status")
+
+// The periodic resync interval.
+var ResyncPeriod = 2 * time.Minute
+
+// Add creates a new Status Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, status *statusmanager.StatusManager, sharedInfo *sharedinfo.SharedInfo) error {
+	return add(mgr, newReconciler(mgr, status, sharedInfo))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager, status *statusmanager.StatusManager, sharedInfo *sharedinfo.SharedInfo) reconcile.Reconciler {
+	return &ReconcileStatus{client: mgr.GetClient(), scheme: mgr.GetScheme(), status: status, sharedInfo: sharedInfo}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("status-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to status of cluster operator object
+	err = c.Watch(&source.Kind{Type: &configv1.ClusterOperator{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileStatus implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileStatus{}
+
+// ReconcileStatus reconciles a ClusterOperator object
+type ReconcileStatus struct {
+	client     client.Client
+	scheme     *runtime.Scheme
+	status     *statusmanager.StatusManager
+	sharedInfo *sharedinfo.SharedInfo
+}
+
+// Reconcile sync the AntreaInstallStatus from antrea ClusterOperator.Status
+func (r *ReconcileStatus) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
+	if request.Name != operatortypes.AntreaClusterOperatorName {
+		return reconcile.Result{}, nil
+	}
+
+	reqLogger.Info("Reconciling status update")
+	if err := r.SyncAntreaInstallStatus(); err != nil {
+		log.Error(err, "Failed to sync the status of AntreaInstall")
+		if apierrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{Requeue: true}, err
+	}
+
+	return reconcile.Result{RequeueAfter: ResyncPeriod}, nil
+}
+
+func (r *ReconcileStatus) SyncAntreaInstallStatus() error {
+	co := &configv1.ClusterOperator{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: operatortypes.AntreaClusterOperatorName}, co)
+	if err != nil {
+		return err
+	}
+
+	antreaInstall := &operatorv1.AntreaInstall{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: operatortypes.OperatorNameSpace, Name: operatortypes.OperatorConfigName}, antreaInstall)
+	if err != nil {
+		return err
+	}
+
+	if reflect.DeepEqual(co.Status.Conditions, antreaInstall.Status.Conditions) {
+		return nil
+	}
+	coStatus := co.Status.DeepCopy()
+	antreaInstall.Status.Conditions = coStatus.Conditions
+	return r.client.Status().Update(context.TODO(), antreaInstall)
+}

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -4,6 +4,9 @@
 package types
 
 const (
+	AntreaClusterOperatorName = "antrea"
+	ReleaseVersion            = "ReleaseVersion"
+
 	AntreaImageRenderKey = "AntreaImage"
 
 	AntreaAgentConfigOption    = "antrea-agent.conf"


### PR DESCRIPTION
1. Update antreainstall.status from antrea clusteroperator.status.
2. Show operator version in status.
3. Optimize config reconciliation:
    - If thre are only status fields changes in cluster config or
      antreainstall object, skip config difference check.

Signed-off-by: Rui Cao <rcao@vmware.com>